### PR TITLE
Added context manager support for StreamManagerClient

### DIFF
--- a/stream_manager/streammanagerclient.py
+++ b/stream_manager/streammanagerclient.py
@@ -111,6 +111,12 @@ class StreamManagerClient:
         self.connected = False
         UtilInternal.sync(self.__connect(), loop=self.__loop)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     async def _close(self):
         if self.__writer is not None:
             self.__closed = True


### PR DESCRIPTION
Issue #5 

Added `__enter__` and `__exit__` boilerplate that should make StreamManagerClient work with the `with` statement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
